### PR TITLE
chore: add workflow to create testing-prelease artifacts

### DIFF
--- a/.github/workflows/testing-build.yaml
+++ b/.github/workflows/testing-build.yaml
@@ -1,0 +1,190 @@
+#
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Create next testing build
+run-name: Testing build of Podman Desktop
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      organization:
+        default: 'podman-desktop'
+        description: 'Organization of the Podman Desktop repository'
+        type: string
+        required: true
+      repositoryName:
+        default: 'podman-desktop'
+        description: 'Podman Desktop repository name'
+        type: string
+        required: true
+      branch:
+        default: 'main'
+        description: 'Podman Desktop repo branch'
+        type: string
+        required: true
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+
+  tag:
+    name: Tagging
+    runs-on: ubuntu-24.04
+    outputs:
+      githubTag: ${{ steps.TAG_UTIL.outputs.githubTag }}
+      desktopVersion: ${{ steps.TAG_UTIL.outputs.desktopVersion }}
+      releaseId: ${{ steps.create_release.outputs.id }}
+
+    steps:
+      # we may run job on schedule or on demand, we need to have default values set for nightly builds
+      - name: Set the default env. variables
+        env:
+          DEFAULT_ORG: 'podman-desktop'
+          DEFAULT_REPO: 'podman-desktop'
+          DEFAULT_BRANCH: 'main'
+        run: |
+          echo "ORGANIZATION=${{ github.event.inputs.organization || env.DEFAULT_ORG }}" >> $GITHUB_ENV
+          echo "REPOSITORY=${{ github.event.inputs.repositoryName || env.DEFAULT_REPO }}" >> $GITHUB_ENV
+          echo "BRANCH=${{ github.event.inputs.branch || env.DEFAULT_BRANCH }}" >> $GITHUB_ENV
+
+      # we need to checkout the podman-desktop repo and switch to that subfolder
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ env.ORGANIZATION }}/${{ env.REPOSITORY }}
+          path: ${{ env.REPOSITORY }}
+          ref: ${{ env.BRANCH }}
+          fetch-depth: 0
+
+      - name: Generate tag utilities
+        working-directory: ${{ env.REPOSITORY }}
+        id: TAG_UTIL
+        run: |
+            CURRENT_DAY=$(date +'%Y%m%d')
+            SHORT_SHA1=$(git rev-parse --short HEAD)
+            # grab the version from the package.json
+            PODMAN_DEKSTOP_VERSION=$(jq -r '.version' package.json)
+            # remove the -next from the version
+            STRIPPED_VERSION=${PODMAN_DEKSTOP_VERSION%-next}
+            TAG_PATTERN=${STRIPPED_VERSION}-$(date +'%Y%m%d%H%M')-${SHORT_SHA1}
+            echo "githubTag=v$TAG_PATTERN" >> ${GITHUB_OUTPUT}
+            echo "desktopVersion=$TAG_PATTERN" >> ${GITHUB_OUTPUT}
+            # check for tag existence - exit the workflow
+            echo "Checking if tag exists: $(git rev-parse -q --verify "$githubTag")"
+            if [ git rev-parse -q --verify "$githubTag" ]; then
+              echo "Tag '$githubTag' exists, skipping..."
+              exit 1;
+            else 
+              echo "Tag '$githubTag' does not exist yet"
+            fi
+
+      - name: Create a Tag, commit and push to testing-prereleases
+        working-directory: ${{ env.REPOSITORY }}
+        run: |
+          # quite heavy solution, we might only consider crating a tag, but not actually pushing whole state of the repo
+          echo "Setting github.actor: ${{ github.actor }} and id: ${{ github.actor_id }}"
+          git config --local user.name ${{ github.actor }}
+          git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ steps.TAG_UTIL.outputs.desktopVersion }}\",#g" package.json
+          find extensions/* -maxdepth 2 -name "package.json" | xargs -I {} sed -i "s#version\":\ \"\(.*\)\",#version\":\ \"${{ steps.TAG_UTIL.outputs.desktopVersion }}\",#g" {}
+          # change the repository field to be the prerelease repository in package.json file
+          sed -i "s#\"repository\":\ \"\(.*\)\",#\"repository\":\ \"https://github.com/podman-desktop/testing-prereleases\",#g" package.json
+          cat package.json
+          git add package.json extensions/*/package.json
+          # get rid of .github/workflows - requires additional permissions
+          rm -rf .github/workflows/*
+          git add .github/
+          git commit -m "chore: tag ${{ steps.TAG_UTIL.outputs.githubTag }}"
+          echo "Tagging with ${{ steps.TAG_UTIL.outputs.githubTag }}"
+          git tag ${{ steps.TAG_UTIL.outputs.githubTag }}
+          # push tag to the prereleases repository
+          git remote add prereleases https://github.com/podman-desktop/testing-prereleases
+          git push prereleases ${{ steps.TAG_UTIL.outputs.githubTag }}
+
+      - name: Create Release
+        id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.TAG_UTIL.outputs.githubTag }}
+          name: ${{ steps.TAG_UTIL.outputs.githubTag }}
+          draft: true
+          prerelease: true
+
+  build:
+    name: Build / ${{ matrix.os }}
+    needs: tag
+    runs-on: ${{ matrix.os }}
+    env:
+      ELECTRON_ENABLE_INSPECT: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2022, macos-14]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: podman-desktop/testing-prereleases
+          ref: ${{ needs.tag.outputs.githubTag }}
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Execute pnpm
+        run: pnpm install
+
+      - name: Run Build on Ubuntu
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
+        timeout-minutes: 40
+        run: pnpm compile:next --linux tar.gz
+
+      - name: Run Build on Mac OS
+        if: startsWith(matrix.os, 'macos')
+        timeout-minutes: 40
+        run: pnpm compile:next --mac dmg
+
+      - name: Run Build on Windows
+        if: startsWith(matrix.os, 'windows')
+        timeout-minutes: 40
+        run: pnpm compile:next --win portable
+
+  release:
+    needs: [tag, build]
+    name: Release
+    runs-on: ubuntu-24.04
+    steps:
+      - name: id
+        run: echo the release id is ${{ needs.tag.outputs.releaseId }}
+
+      - name: Publish release
+        uses: StuYarrow/publish-release@v1.1.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          id: ${{ needs.tag.outputs.releaseId }}
+          repo: testing-prereleases
+          owner: podman-desktop


### PR DESCRIPTION
First proposal is quite similar to next-build job on podman-desktop. Checkout the podman-desktop main branch, create a tag and push a commit to `testing-prereleases` (only if it does not exist). Then build a podman-desktop on linux as tar.gz, on mac as dmg and on windows as .exe with `ELECTRON_ENABLE_INSPECT=true` and publish it on a release on the repo. Runs 4 times a day (at 0, 6, 12, 18 hour). 

Can be run on demand. Ie. to produce a testing builds for staged releases.

Fixes https://github.com/podman-desktop/podman-desktop/issues/8957